### PR TITLE
Replace instanceOf with Buffer.isBuffer()

### DIFF
--- a/lib/Layout.js
+++ b/lib/Layout.js
@@ -1765,7 +1765,7 @@ class Union extends Layout {
    */
   getVariant(vb, offset) {
     let variant = vb;
-    if (vb instanceof Buffer) {
+    if (Buffer.isBuffer(vb)) {
       if (undefined === offset) {
         offset = 0;
       }
@@ -2325,7 +2325,7 @@ class Blob extends Layout {
     if (this.length instanceof ExternalLayout) {
       span = src.length;
     }
-    if (!((src instanceof Buffer)
+    if (!(Buffer.isBuffer(src)
           && (span === src.length))) {
       throw new TypeError(nameWithProperty('Blob.encode', this)
                           + ' requires (length ' + span + ') Buffer as src');
@@ -2361,7 +2361,7 @@ class CString extends Layout {
 
   /** @override */
   getSpan(b, offset) {
-    if (!(b instanceof Buffer)) {
+    if (!Buffer.isBuffer(b)) {
       throw new TypeError('b must be a Buffer');
     }
     if (undefined === offset) {
@@ -2452,7 +2452,7 @@ class UTF8 extends Layout {
 
   /** @override */
   getSpan(b, offset) {
-    if (!(b instanceof Buffer)) {
+    if (!Buffer.isBuffer(b)) {
       throw new TypeError('b must be a Buffer');
     }
     if (undefined === offset) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "buffer-layout",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Translation between JavaScript values and Buffers",
   "keywords": [
     "Buffer",


### PR DESCRIPTION
Motivation: `instanceOf` check may fail in browser environment where multiple versions of the buffer package may be bundled together, hence resulting in different instances of Buffer being present in the code. A more "resilient" way of checking whether the parameter supplied is a buffer is the `Buffer.isBuffer()` method  which I'm migrating to in this PR

Testing: `yarn test` passes

more info:
https://github.com/feross/buffer/issues/154