### PR TITLE
browser compat: assert does not exist in browsers

### DIFF
--- a/lib/Layout.js
+++ b/lib/Layout.js
@@ -132,8 +132,6 @@
 
 'use strict';
 
-const assert = require('assert');
-
 /**
  * Base class for layout objects.
  *
@@ -1265,7 +1263,9 @@ class Structure extends Layout {
         /* By construction the field must be fixed-length (because
          * unnamed variable-length fields are disallowed when
          * encoding).  But check it anyway. */
-        assert(0 < span);
+        if (span < 0) {
+          throw new Error("AssertionError [ERR_ASSERTION]: The expression evaluated to a falsy value");
+        }
       } else {
         const fv = src[fd.property];
         if (undefined !== fv) {


### PR DESCRIPTION
this change makes package more compatible with tools used in esm environment 