### PR TITLE
Layout: remove dependency on assert module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## [1.2.2] - 2021-07-05
+
+* Improve [browser compatibility][pr#26] by eliminating a dependence on
+  the Node assert module.
+
 ## [1.2.1] - 2021-04-29
 
 * Improve [browser compatibility][pr#24] by using `Buffer.isBuffer` instead of
@@ -136,6 +141,7 @@
 
 * Initial release.
 
+[1.2.2]: https://github.com/pabigot/buffer-layout/compare/v1.2.1...v1.2.2
 [1.2.1]: https://github.com/pabigot/buffer-layout/compare/v1.2.0...v1.2.1
 [1.2.0]: https://github.com/pabigot/buffer-layout/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/pabigot/buffer-layout/compare/v1.0.0...v1.1.0
@@ -200,6 +206,7 @@
 [issue#20]: https://github.com/pabigot/buffer-layout/issues/20
 [issue#21]: https://github.com/pabigot/buffer-layout/issues/21
 [pr#24]: https://github.com/pabigot/buffer-layout/pull/24
+[pr#26]: https://github.com/pabigot/buffer-layout/pull/26
 [ci:travis]: https://travis-ci.org/pabigot/buffer-layout
 [ci:coveralls]: https://coveralls.io/github/pabigot/buffer-layout
 [node:issue#3992]: https://github.com/nodejs/node/issues/3992

--- a/lib/Layout.js
+++ b/lib/Layout.js
@@ -132,8 +132,6 @@
 
 'use strict';
 
-const assert = require('assert');
-
 /**
  * Base class for layout objects.
  *
@@ -715,8 +713,6 @@ const V2E32 = Math.pow(2, 32);
 function divmodInt64(src) {
   const hi32 = Math.floor(src / V2E32);
   const lo32 = src - (hi32 * V2E32);
-  // assert.equal(roundedInt64(hi32, lo32), src);
-  // assert(0 <= lo32);
   return {hi32, lo32};
 }
 /* Reconstruct Number from quotient and non-negative remainder */
@@ -1261,12 +1257,7 @@ class Structure extends Layout {
     for (const fd of this.fields) {
       let span = fd.span;
       lastWrote = (0 < span) ? span : 0;
-      if (undefined === fd.property) {
-        /* By construction the field must be fixed-length (because
-         * unnamed variable-length fields are disallowed when
-         * encoding).  But check it anyway. */
-        assert(0 < span);
-      } else {
+      if (undefined !== fd.property) {
         const fv = src[fd.property];
         if (undefined !== fv) {
           lastWrote = fd.encode(fv, b, offset);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "buffer-layout",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Translation between JavaScript values and Buffers",
   "keywords": [
     "Buffer",

--- a/test/LayoutTest.js
+++ b/test/LayoutTest.js
@@ -672,7 +672,8 @@ suite('Layout', function() {
       assert.throws(() => new lo.Structure('stuff'), TypeError);
       assert.throws(() => new lo.Structure(['stuff']), TypeError);
       // no unnamed variable-length fields
-      assert.throws(() => new lo.Structure([lo.cstr()]), Error);
+      assert.throws(() => new lo.Structure([lo.cstr()]),
+                    err => checkError(err, Error, /cannot contain unnamed variable-length layout/));
     });
     test('basics', function() {
       const st = new lo.Structure([lo.u8('u8'),


### PR DESCRIPTION
Apparently some environments where this package is being used do not
support an assert API.  The only use of the API was a sanity check
that unnamed fields were defined with a fixed length.  A comment
noted, and inspection confirms, that the Structure constructor
explicitly rejects attempts to define such a field.  So just drop the
check.

Signed-off-by: Peter A. Bigot <pab@pabigot.com>